### PR TITLE
remove pandas-stubs from base

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 7f69676b67833b252e3799ea7f52993b08a668aeba4879892e0d729203435657
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: pandera-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,6 @@ outputs:
         - python >=3.7
         - numpy >=1.9.0
         - pandas >=1.0
-        - pandas-stubs
         - typing_extensions
         - typing_inspect >=0.6.0
         - wrapt


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Thanks for maintaining this :heart: !

Notes:
- sync with upstream `setup.py`
  - removes `pandas-stubs` from `pandera-core`
    - see also https://github.com/conda-forge/pandas-stubs-feedstock/pull/97