### PR TITLE
fix missing `setuptools-scm` in host environment

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 2afa00945ebe00558b5240c988effff48ec806e3ede6bd19a574f2a5f1abe214
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: pandera-base
@@ -22,7 +22,8 @@ outputs:
     requirements:
       host:
         - python {{ python_min }}
-        - setuptools
+        - setuptools >=61.0
+        - setuptools-scm >=8.0.1
         - pip
       run:
         - python >={{ python_min }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
